### PR TITLE
Update description of Inference Benchmark project

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
 
 ### Benchmark
 
-* **[Inference Benchmark](https://github.com/AI-Hypercomputer/inference-benchmark)**: None ![Stars](https://img.shields.io/github/stars/AI-Hypercomputer/inference-benchmark.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/AI-Hypercomputer/inference-benchmark?color=green) ![LastCommit](https://img.shields.io/github/last-commit/AI-Hypercomputer/inference-benchmark?color=green)
+* **[Inference Benchmark](https://github.com/AI-Hypercomputer/inference-benchmark)**: A model server agnostic inference benchmarking tool that can be used to benchmark LLMs running on differet infrastructure like GPU and TPU. It can also be run on a GKE cluster as a container. ![Stars](https://img.shields.io/github/stars/AI-Hypercomputer/inference-benchmark.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/AI-Hypercomputer/inference-benchmark?color=green) ![LastCommit](https://img.shields.io/github/last-commit/AI-Hypercomputer/inference-benchmark?color=green)
 * **[Inference Perf](https://github.com/kubernetes-sigs/inference-perf)**: GenAI inference performance benchmarking tool ![Stars](https://img.shields.io/github/stars/kubernetes-sigs/inference-perf.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/kubernetes-sigs/inference-perf?color=green) ![LastCommit](https://img.shields.io/github/last-commit/kubernetes-sigs/inference-perf?color=green)
 
 ### Output

--- a/website/data.yml
+++ b/website/data.yml
@@ -225,7 +225,9 @@ categories:
   - name: Benchmark
     items:
     - name: Inference Benchmark
-      description: null
+      description: A model server agnostic inference benchmarking tool that can be
+        used to benchmark LLMs running on differet infrastructure like GPU and TPU.
+        It can also be run on a GKE cluster as a container.
       homepage_url: https://github.com/AI-Hypercomputer/inference-benchmark
       logo: inference-benchmark.png
       repo_url: https://github.com/AI-Hypercomputer/inference-benchmark


### PR DESCRIPTION
The description in the [inference-benchmark](https://github.com/AI-Hypercomputer/inference-benchmark) project is empty, so our script didn't fill it properly.