### PR TITLE
Add OneComp (Fujitsu) to Inference/Quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
 ## Inference
 
+| [OneComp](https://github.com/FujitsuResearch/OneCompression) | ![](https://img.shields.io/github/stars/FujitsuResearch/OneCompression.svg?style=social) | Apache-2.0 | LLM post-training quantization pipeline with QEP/AutoBit/JointQ + vLLM plugin (arXiv:2603.28845). |
+
 ### Inference Engine
 
 * **[Cortex.cpp](https://github.com/janhq/cortex.cpp)**: Local AI API Platform. ![Stars](https://img.shields.io/github/stars/janhq/cortex.cpp.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/janhq/cortex.cpp?color=green) ![LastCommit](https://img.shields.io/github/last-commit/janhq/cortex.cpp?color=green)


### PR DESCRIPTION
## Summary

This PR adds **OneComp** (Fujitsu Research, [arXiv:2603.28845](https://arxiv.org/abs/2603.28845)) and its accompanying NeurIPS 2025 paper **QEP** to this awesome list.

OneComp is an open-source, Apache-2.0 licensed post-training quantization (PTQ) framework for LLMs that unifies several recent research directions behind a single `Runner.auto_run()` API:

- **QEP** (Quantization Error Propagation, NeurIPS 2025) — layer-wise PTQ with propagated error compensation.
- **AutoBit** — ILP-based mixed-precision bitwidth assignment derived from available VRAM.
- **JointQ** — joint weight–scale optimization (group-wise 4-bit, etc.).
- **Rotation preprocessing** — SpinQuant/OstQuant-style learned rotations absorbed into weights, with online Hadamard hooks at load time.
- **LoRA SFT post-process** — accuracy recovery / knowledge injection after quantization.
- **vLLM plugin** — first-class DBF & Mixed-GPTQ serving of OneComp checkpoints.

Verified on Llama (TinyLlama / Llama-2 / Llama-3) and Qwen3 (0.6B — 32B). PyPI: `pip install onecomp`.

Links:
- Repo: https://github.com/FujitsuResearch/OneCompression
- Paper (OneComp): https://arxiv.org/abs/2603.28845
- Paper (QEP, NeurIPS 2025): https://openreview.net/forum?id=a3l3K9khbL
- Docs: https://FujitsuResearch.github.io/OneCompression/

Happy to adjust section placement, wording, or formatting to better match the list's conventions — thanks for maintaining this resource!
