### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 
 ### Observation
 
+* **[agenttrace](https://github.com/luoyuctl/agenttrace)**: TUI observability for AI coding agents: traces cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates for Claude Code, Codex CLI, Gemini CLI, Aider, and Cursor exports. ![Stars](https://img.shields.io/github/stars/luoyuctl/agenttrace.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/luoyuctl/agenttrace?color=green) ![LastCommit](https://img.shields.io/github/last-commit/luoyuctl/agenttrace?color=green)
 * **[OpenLLMetry](https://github.com/traceloop/openllmetry)**: Open-source observability for your LLM application, based on OpenTelemetry. ![Stars](https://img.shields.io/github/stars/traceloop/openllmetry.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/traceloop/openllmetry?color=green) ![LastCommit](https://img.shields.io/github/last-commit/traceloop/openllmetry?color=green)
 * **[wandb](https://github.com/wandb/wandb)**: The AI developer platform. Use Weights & Biases to train and fine-tune models, and manage models from experimentation to production. ![Stars](https://img.shields.io/github/stars/wandb/wandb.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/wandb/wandb?color=green) ![LastCommit](https://img.shields.io/github/last-commit/wandb/wandb?color=green)
 

--- a/website/data.yml
+++ b/website/data.yml
@@ -954,6 +954,13 @@ categories:
       repo_url: https://github.com/e2b-dev/E2B
   - name: Observation
     items:
+    - name: agenttrace
+      description: 'TUI observability for AI coding agents: traces cost, tokens,
+        tool failures, latency, anomalies, health, diffs, and CI gates for Claude
+        Code, Codex CLI, Gemini CLI, Aider, and Cursor exports.'
+      homepage_url: https://luoyuctl.github.io/agenttrace/
+      logo: default.png
+      repo_url: https://github.com/luoyuctl/agenttrace
     - name: OpenLLMetry
       description: Open-source observability for your LLM application, based on OpenTelemetry.
       homepage_url: https://www.traceloop.com/openllmetry


### PR DESCRIPTION
## Summary
- Add agenttrace to the Runtime / Observation section.
- Update both README.md and website/data.yml using the repository project request workflow.
- Use the existing default logo asset.

## Validation
- `python3 project_request.py --category "Runtime/Observation" --repo_url https://github.com/luoyuctl/agenttrace --name agenttrace --homepage_url https://luoyuctl.github.io/agenttrace/`
- Parsed `website/data.yml` with PyYAML and confirmed the agenttrace entry under Runtime / Observation.
- `git diff --check`
- `make validate` was attempted but could not run because `landscape2` is not installed in this environment.