### PR TITLE
Add Ingero under Runtime -> Observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 
 ### Observation
 
+* **[Ingero](https://github.com/ingero-io/ingero)**: Open-source eBPF agent and MCP server for GPU causal observability. Traces the chain from Linux kernel events through CUDA APIs to Python source lines for PyTorch / vLLM workloads, with <2% overhead and zero code changes. ![Stars](https://img.shields.io/github/stars/ingero-io/ingero.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/ingero-io/ingero?color=green) ![LastCommit](https://img.shields.io/github/last-commit/ingero-io/ingero?color=green)
 * **[OpenLLMetry](https://github.com/traceloop/openllmetry)**: Open-source observability for your LLM application, based on OpenTelemetry. ![Stars](https://img.shields.io/github/stars/traceloop/openllmetry.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/traceloop/openllmetry?color=green) ![LastCommit](https://img.shields.io/github/last-commit/traceloop/openllmetry?color=green)
 * **[wandb](https://github.com/wandb/wandb)**: The AI developer platform. Use Weights & Biases to train and fine-tune models, and manage models from experimentation to production. ![Stars](https://img.shields.io/github/stars/wandb/wandb.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/wandb/wandb?color=green) ![LastCommit](https://img.shields.io/github/last-commit/wandb/wandb?color=green)
 


### PR DESCRIPTION
Adds Ingero under **Runtime -> Observation**.

Ingero is an open-source (Apache 2.0 + GPL-2.0) eBPF agent and MCP server for GPU causal observability of LLM workloads. It complements OpenLLMetry / wandb at a different layer: instead of tracing LLM API calls, it traces Linux kernel events + CUDA API calls + Python frames during PyTorch / vLLM training and inference.

- DaemonSet on Kubernetes via Helm.
- MCP server (`ingero mcp`) lets an LLM agent investigate a GPU stall and get back a resolved causal chain with Python source lines.
- One binary, <2% overhead, zero code changes.

Repo: https://github.com/ingero-io/ingero
