### PR TITLE
Add Paralleliq — model-aware GPU control plane for AI inference clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 * **[Modular](https://github.com/modular/modular)**: The Modular Platform (includes MAX & Mojo) ![Stars](https://img.shields.io/github/stars/modular/modular.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/modular/modular?color=green) ![LastCommit](https://img.shields.io/github/last-commit/modular/modular?color=green)
 * **[Mooncake](https://github.com/kvcache-ai/Mooncake)**: Mooncake is the serving platform for Kimi, a leading LLM service provided by Moonshot AI. ![Stars](https://img.shields.io/github/stars/kvcache-ai/mooncake.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/kvcache-ai/mooncake?color=green) ![LastCommit](https://img.shields.io/github/last-commit/kvcache-ai/mooncake?color=green)
 * **[OME](https://github.com/sgl-project/ome)**: OME is a Kubernetes operator for enterprise-grade management and serving of Large Language Models (LLMs) ![Stars](https://img.shields.io/github/stars/sgl-project/ome.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/sgl-project/ome?color=green) ![LastCommit](https://img.shields.io/github/last-commit/sgl-project/ome?color=green)
+* **[Paralleliq](https://www.paralleliq.ai)**: Model-aware GPU control plane for AI inference clusters. Understands which model runs on which GPU, detects tier misplacement, dark capacity, OOM risk, and CPU:GPU imbalance — with human-in-the-loop approval workflows and a full audit trail.
 
 ### Middleware
 


### PR DESCRIPTION
**[Paralleliq](https://www.paralleliq.ai)** is a model-aware GPU control plane that sits above inference clusters and understands both the infrastructure and the models running on it.

Most tools in the Inference Platform section handle *how* models are served. Paralleliq handles *where* models are placed and *whether* they are placed correctly. It detects four patterns that cause 20-40% GPU spend overhead in production inference:

- **Tier misplacement** - a 7B model running on an H100 that only needs an A10G
- **Dark capacity** - GPUs allocated to deployments with no live traffic
- **OOM risk** - models approaching their GPU memory ceiling
- **CPU:GPU imbalance** - CPU saturation throttling GPU throughput in agentic workloads

Each finding is quantified in dollars and delivered with human-in-the-loop approval workflows and a full audit trail. Also ships **piqc** (https://github.com/paralleliq/piqc), an open-source read-only scanner for quick fleet audits.

Added to Inference Platform as the management/control layer for teams running these systems at scale.
