### PR TITLE
Add DOS Kernel to Observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@
 
 ### Observation
 
+* **[DOS Kernel](https://github.com/anthony-chaudhary/dos-kernel)**: Deterministic trust kernel for AI-agent fleets — verifies agent "done" claims from git evidence, arbitrates concurrent file access, and audits commit claims against their own diffs. ![Stars](https://img.shields.io/github/stars/anthony-chaudhary/dos-kernel.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/anthony-chaudhary/dos-kernel?color=green) ![LastCommit](https://img.shields.io/github/last-commit/anthony-chaudhary/dos-kernel?color=green)
 * **[OpenLLMetry](https://github.com/traceloop/openllmetry)**: Open-source observability for your LLM application, based on OpenTelemetry. ![Stars](https://img.shields.io/github/stars/traceloop/openllmetry.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/traceloop/openllmetry?color=green) ![LastCommit](https://img.shields.io/github/last-commit/traceloop/openllmetry?color=green)
 * **[wandb](https://github.com/wandb/wandb)**: The AI developer platform. Use Weights & Biases to train and fine-tune models, and manage models from experimentation to production. ![Stars](https://img.shields.io/github/stars/wandb/wandb.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/wandb/wandb?color=green) ![LastCommit](https://img.shields.io/github/last-commit/wandb/wandb?color=green)
 


### PR DESCRIPTION
Adds DOS Kernel — https://github.com/anthony-chaudhary/dos-kernel — to **Runtime › Observation** (alphabetical slot, three-badge format).

DOS is a deterministic trust kernel for AI coding agents and agent fleets. It computes verdicts from evidence the agent didn't author: `dos verify` checks that a claimed unit of work actually landed (git ancestry, not self-report), `dos arbitrate` decides whether two concurrent agents may touch the same files, and `dos commit-audit` flags a commit whose message claims work its own diff doesn't contain. MIT-licensed, Python (PyPI: `dos-kernel`), ships an MCP server (`dos-mcp`) and hooks for Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and Claude Cowork.

Placement follows the list's contribution guidelines; link verified.