### PR TITLE
Add ax to Observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@
 
 ### Observation
 
+* **[ax](https://github.com/Necmttn/ax)**: Local-first observability and memory graph for AI coding agents, with dashboard, OTLP receiver, cost analytics, and MCP queries. ![Stars](https://img.shields.io/github/stars/Necmttn/ax.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/Necmttn/ax?color=green) ![LastCommit](https://img.shields.io/github/last-commit/Necmttn/ax?color=green)
 * **[OpenLLMetry](https://github.com/traceloop/openllmetry)**: Open-source observability for your LLM application, based on OpenTelemetry. ![Stars](https://img.shields.io/github/stars/traceloop/openllmetry.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/traceloop/openllmetry?color=green) ![LastCommit](https://img.shields.io/github/last-commit/traceloop/openllmetry?color=green)
 * **[wandb](https://github.com/wandb/wandb)**: The AI developer platform. Use Weights & Biases to train and fine-tune models, and manage models from experimentation to production. ![Stars](https://img.shields.io/github/stars/wandb/wandb.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/wandb/wandb?color=green) ![LastCommit](https://img.shields.io/github/last-commit/wandb/wandb?color=green)
 

--- a/website/data.yml
+++ b/website/data.yml
@@ -961,6 +961,12 @@ categories:
       repo_url: https://github.com/e2b-dev/E2B
   - name: Observation
     items:
+    - name: ax
+      description: Local-first observability and memory graph for AI coding agents,
+        with dashboard, OTLP receiver, cost analytics, and MCP queries.
+      homepage_url: https://github.com/Necmttn/ax
+      logo: ax.svg
+      repo_url: https://github.com/Necmttn/ax
     - name: OpenLLMetry
       description: Open-source observability for your LLM application, based on OpenTelemetry.
       homepage_url: https://www.traceloop.com/openllmetry

--- a/website/logos/ax.svg
+++ b/website/logos/ax.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1000 1000">
+  <rect width="1000" height="1000" rx="222" fill="#0b0f0d"/>
+  <text x="500" y="565" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-weight="700" font-size="380" letter-spacing="-8">
+    <tspan fill="#8a948e">n</tspan><tspan fill="#4f7cff">/</tspan><tspan fill="#ffffff">ax</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- Add ax to Runtime / Observation in README.md.
- Add the matching landscape entry in website/data.yml.
- Add a local SVG logo asset for the landscape.

## Validation
- `git diff --check`
- Parsed `website/data.yml` with Ruby YAML and verified ax appears in Runtime / Observation
- Verified `Necmttn/ax` is active and not archived via the GitHub API

Note: `make validate` could not run locally because `landscape2` is not installed; the Docker fallback was blocked by the container registry rate limit.

---

_Generated with [ax](https://github.com/Necmttn/ax)._