### PR TITLE
Add KV Cache Store to Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@
 * **[kvcached](https://github.com/ovg-project/kvcached)**: Virtualized Elastic KV Cache for Dynamic GPU Sharing and Beyond ![Stars](https://img.shields.io/github/stars/ovg-project/kvcached.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/ovg-project/kvcached?color=green) ![LastCommit](https://img.shields.io/github/last-commit/ovg-project/kvcached?color=green)
 * **[LMCache](https://github.com/LMCache/LMCache)**: 10x Faster Long-Context LLM By Smart KV Cache Optimizations. ![Stars](https://img.shields.io/github/stars/lmcache/lmcache.svg?style=flat&color=green) ![Contributors](https://img.shields.io/github/contributors/lmcache/lmcache?color=green) ![LastCommit](https://img.shields.io/github/last-commit/lmcache/lmcache?color=green) ![Tag](https://img.shields.io/badge/kvcache-orange)
 
+* **[KV Cache Store](https://kvcachestore.com/)**: Hosted KV-cache artifact registry plus an open-source Rust CLI. Precompute, verify, quantize, and share attention states across RAG and long-context prompts to cut prefill cost and latency. ![Website](https://img.shields.io/badge/Website-kvcachestore.com-blue) ([CLI source](https://github.com/kvcachestore/kvcdn))
+
 
 ### LLM Router
 


### PR DESCRIPTION
KV Cache Store is a hosted KV-cache artifact registry plus an open-source Rust CLI. It lets teams precompute, verify, quantize, and share key/value cache artifacts across RAG and long-context LLM inference runs to reduce prefill cost and latency.\n\n- Website: https://kvcachestore.com/\n- CLI repo: https://github.com/kvcachestore/kvcdn